### PR TITLE
help to fix issue #12 for doi query.

### DIFF
--- a/wos/utils.py
+++ b/wos/utils.py
@@ -33,5 +33,5 @@ def query(wosclient, wos_query, xml_query=None, count=5, offset=1, limit=100):
 
 def doi_to_wos(wosclient, doi):
     """Convert DOI to WOS identifier."""
-    results = query(wosclient, 'DO=%s' % doi, './REC/UID', count=1)
+    results = query(wosclient, 'DO="%s"' % doi, './REC/UID', count=1)
     return results[0].lstrip('WOS:') if results else None


### PR DESCRIPTION
I figured the same issues and succeeded to query by DOI adding additional double quotes.
Next command works in the same way:
`wos -s=C6O7gwblahblahpqbn query 'DO="10.1016/S0030-4018(98)00633-6"'`
`wos -s=C6O7gwEV6x4ZYYDpqbn doi "10.1016/S0030-4018(98)00633-6"`
`wos -s=C6O7gwEV6x4ZYYDpqbn doi '10.1016/S0030-4018(98)00633-6'`

but this one fails:
`wos -s=C6O7gwblahblahpqbn query "DO='10.1016/S0030-4018(98)00633-6'"`

Quoting often is subtle ;)